### PR TITLE
Properly fetch module directory

### DIFF
--- a/wplib.php
+++ b/wplib.php
@@ -1418,11 +1418,9 @@ class WPLib {
 
 		foreach ( self::get_module_classes( $app_class ) as $module_class => $module_filepath ) {
 
-			$try_dir = dirname( $module_filepath );
+			if ( 0 === strpos( $filepath, $module_filepath ) ) {
 
-			if ( 0 === strpos( $filepath, $try_dir ) ) {
-
-				$module_dir = self::maybe_make_absolute_path( $try_dir, ABSPATH );
+				$module_dir = self::maybe_make_absolute_path( $module_filepath, ABSPATH );
 
 				break;
 


### PR DESCRIPTION
$try_dir isn't necessary as $module_filepath is actually the module's root directory.  If there are cases where this isn't true, perhaps we should check both the $module_filepath and $try_dir?
